### PR TITLE
OPS-2377: null pointer exception

### DIFF
--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -189,7 +189,7 @@ func processContainer(
 	taskDefinition *ecs.TaskDefinition) *TargetGroup {
 	targetGroup := &TargetGroup{}
 	// Skip containers with no exposed ports or not in a RUNNING status
-	if *container.LastStatus != "RUNNING" || *taskDefinition.NetworkMode == "none" {
+	if *container.LastStatus != "RUNNING" || taskDefinition.NetworkMode == nil || *taskDefinition.NetworkMode == "none" {
 		return targetGroup
 	}
 


### PR DESCRIPTION
Some task definitions could have NetworkMode field of the container set
to 0. It is a pointer, so dereference will lead to segmentation fault.
Adding check for the pointer value.